### PR TITLE
Update reference to deprecated API

### DIFF
--- a/deployment.yml
+++ b/deployment.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello-app


### PR DESCRIPTION
Per https://www.ibm.com/cloud/blog/announcements/kubernetes-version-1-16-removes-deprecated-apis