### PR TITLE
Remove deprecated api in k8s 1.16 and ensure syntax correct in 1.14

### DIFF
--- a/.tekton/listener.yaml
+++ b/.tekton/listener.yaml
@@ -6,6 +6,8 @@ spec:
   params:
     - name: repository
       description: The git repo
+    - name: revision
+      description: the branch for the git repo
     - name: apikey
       description: the ibmcloud api key
     - name: registryNamespace
@@ -34,6 +36,8 @@ spec:
           value: pipelinerun-$(uid)-pvc
         - name: repository
           value: $(params.repository)
+        - name: revision
+          value: $(params.revision)
         - name: apikey
           value: $(params.apikey)
         - name: registryNamespace
@@ -55,6 +59,8 @@ spec:
   params:
     - name: repository
       value: "https://github.com/open-toolchain/hello-tekton"
+    - name: revision
+      value: "master"
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: EventListener

--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -8,6 +8,8 @@ spec:
       description: the pipeline pvc name
     - name: repository
       description: the git repo
+    - name: revision
+      description: the branch for the git repo
     - name: apikey
       description: the ibmcloud api key
     - name: registryNamespace
@@ -32,6 +34,8 @@ spec:
           value: $(params.pipeline-pvc)
         - name: repository
           value: $(params.repository)
+        - name: revision
+          value: $(params.revision)
         - name: apikey
           value: $(params.apikey)
         - name: registryNamespace
@@ -47,6 +51,8 @@ spec:
           value: $(params.pipeline-pvc)
         - name: repository
           value: $(params.repository)
+        - name: revision
+          value: $(params.revision)
         - name: apikey
           value: $(params.apikey)
         - name: registryRegion
@@ -60,6 +66,8 @@ spec:
           value: $(params.pipeline-pvc)
         - name: repository
           value: $(params.repository)
+        - name: revision
+          value: $(params.revision)
         - name: apikey
           value: $(params.apikey)
         - name: cluster

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ In order to build and deploy to your own cluster this sample requires parameteri
 - `clusterRegion` the region where your IKS cluster is located (default: `us-south`)
 - `registryNamespace` the IBM Cloud Container Registry namespace where the app image will be built and stored.
 - `registryRegion` the region where your  IBM Cloud Container Registry is located (default: `us-south`)
-- `repository` the source git repository where your resources are cloned (default: `https://github.com/open-toolchain/hello-tekton`). Change this if you are forking this repo.
+- `repository` the source git repository where your resources are cloned (default: `https://github.com/open-toolchain/hello-tekton`). Change this if you are forking this repo
+- `revision` the branch of the source git repository where your resources are cloned (default: `master`).
 
 For more information on Tekton Pipelines wih IBM Cloud Devops visit https://cloud.ibm.com/docs/services/ContinuousDelivery?topic=ContinuousDelivery-tekton-pipelines
 

--- a/deployment.yml
+++ b/deployment.yml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello-app
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: hello-app
   template:
     metadata:
       labels:


### PR DESCRIPTION
Remove deprecated api in k8s 1.16 and ensure syntax correct in 1.14
Manage branch/revision params down to the the git clone