### PR TITLE
Fix pipeline images

### DIFF
--- a/.tekton/task.yaml
+++ b/.tekton/task.yaml
@@ -38,7 +38,7 @@ spec:
           echo "Cloning $REPOSITORY";
           cd /workspace && git clone -q -b $REVISION $REPOSITORY .;
     - name: pre-build-check
-      image: ibmcom/pipeline-base-image
+      image: icr.io/continuous-delivery/pipeline/pipeline-base-image
       env:
         - name: IBMCLOUD_API_KEY
           value: $(params.apikey)
@@ -59,7 +59,7 @@ spec:
           export NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh";
           cd /workspace && source pre-build-check.sh;
     - name: build-docker-image
-      image: ibmcom/pipeline-base-image
+      image: icr.io/continuous-delivery/pipeline/pipeline-base-image
       env:
         - name: IBMCLOUD_API_KEY
           value: $(params.apikey)
@@ -144,7 +144,7 @@ spec:
           echo "Cloning $REPOSITORY";
           cd /workspace && git clone -q -b $REVISION $REPOSITORY .;
     - name: check-vulnerabilities
-      image: ibmcom/pipeline-base-image
+      image: icr.io/continuous-delivery/pipeline/pipeline-base-image
       env:
         - name: IBMCLOUD_API_KEY
           value: $(params.apikey)
@@ -203,7 +203,7 @@ spec:
           echo "Cloning $REPOSITORY";
           cd /workspace && git clone -q -b $REVISION $REPOSITORY .;
     - name: pre-deploy-check
-      image: ibmcom/pipeline-base-image
+      image: icr.io/continuous-delivery/pipeline/pipeline-base-image
       env:
         - name: IBMCLOUD_API_KEY
           value: $(params.apikey)
@@ -231,7 +231,7 @@ spec:
           cp /artifacts/build.properties .;
           cd /workspace && source pre-deploy-check.sh;
     - name: deploy-to-kubernetes
-      image: ibmcom/pipeline-base-image
+      image: icr.io/continuous-delivery/pipeline/pipeline-base-image
       env:
         - name: IBMCLOUD_API_KEY
           value: $(params.apikey)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Hello-Tekton
+## Hello-Tekton
+
 Use a Tekton pipeline to build and deploy a simple hello world node application with IBM Cloud Devops ( https://cloud.ibm.com/devops).
 
 The `.tekton` folder contains Tekton Resource definitions that create a Tekton PipelineRun. This "runs" a pipeline that builds a simple node application into an image, scans the image for vulnerabilities, and then deploys the application with IBM Cloud Kubernetes Service.


### PR DESCRIPTION
The `ibmcom/pipeline-base-image` images have been removed from DockerHub, they need to be replaced with `icr.io/continuous-delivery/pipeline/pipeline-base-image`. 

See: https://cloud.ibm.com/status/announcement?component=continuous-delivery&query=docker